### PR TITLE
feat: add datos.gob.es and CGPJ national data sources

### DIFF
--- a/src/mcp_govern/barcelona.py
+++ b/src/mcp_govern/barcelona.py
@@ -1,0 +1,114 @@
+"""Client async per a l'Open Data de l'Ajuntament de Barcelona (API CKAN)."""
+
+from __future__ import annotations
+
+import httpx
+
+BASE_URL = "https://opendata-ajuntament.barcelona.cat/data/api/action"
+REQUEST_TIMEOUT = 30.0
+DEFAULT_ROWS = 20
+
+# Datasets destacats per àrea temàtica
+BARCELONA_DATASETS = {
+    # Pressupostos
+    "pressupost_despeses": "pressupost-despeses",
+    "pressupost_ingressos": "pressupost-ingressos",
+    # Contractació
+    "contractes_menors": "contractes-menors",
+    "modificacions_contractes": "modificacions-de-contractes",
+    "prorrogues_contractes": "prorrogues-de-contractes",
+    "relacio_contractistes": "relacio-contractistes",
+    # Seguretat
+    "incidents_gub": "incidents-gestionats-gub",
+    "denuncies_transit": "denuncies_sancions_transit_bcn_detall",
+    # Transport
+    "transports": "transports",
+    "bicing": "bicing",
+    "carril_bici": "carril-bici",
+    "aparcaments": "aparcaments-bcn",
+    # Medi ambient
+    "qualitat_aire": "qualitat-aire-detall-bcn",
+    "espais_verds": "espais-verds-publics",
+    # Habitatge
+    "habitatges_2na_ma": "habitatges-2na-ma",
+    "habitatges_turistic": "habitatges-us-turistic",
+    # Economia
+    "renda_llars": "renda-disponible-llars-bcn",
+    # Urbanisme
+    "obres": "obres",
+}
+
+
+async def cercar_datasets(
+    *,
+    query: str | None = None,
+    rows: int = DEFAULT_ROWS,
+    start: int = 0,
+) -> dict:
+    """Cerca datasets a l'Open Data de Barcelona.
+
+    Args:
+        query: Text lliure per cercar.
+        rows: Nombre de resultats.
+        start: Offset per paginació.
+    """
+    params: dict[str, str | int] = {
+        "rows": rows,
+        "start": start,
+    }
+    if query:
+        params["q"] = query
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(f"{BASE_URL}/package_search", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def detall_dataset(dataset_name: str) -> dict:
+    """Obté el detall complet d'un dataset pel seu nom.
+
+    Args:
+        dataset_name: Nom del dataset (ex: 'pressupost-despeses').
+    """
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(
+            f"{BASE_URL}/package_show",
+            params={"id": dataset_name},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def obtenir_dades(
+    resource_id: str,
+    *,
+    query: str | None = None,
+    filters: dict | None = None,
+    limit: int = DEFAULT_ROWS,
+    offset: int = 0,
+) -> dict:
+    """Obté dades d'un recurs concret via l'API datastore.
+
+    Args:
+        resource_id: ID del recurs (obtingut via detall_dataset).
+        query: Text lliure per filtrar.
+        filters: Diccionari de filtres exactes (camp: valor).
+        limit: Nombre de resultats.
+        offset: Offset per paginació.
+    """
+    params: dict[str, str | int] = {
+        "resource_id": resource_id,
+        "limit": limit,
+        "offset": offset,
+    }
+    if query:
+        params["q"] = query
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(
+            f"{BASE_URL}/datastore_search",
+            params=params,
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/src/mcp_govern/cgpj.py
+++ b/src/mcp_govern/cgpj.py
@@ -1,0 +1,126 @@
+"""Client async per a dades del CGPJ (Consejo General del Poder Judicial).
+
+Accedeix a les estadístiques judicials i al repositori de processos
+per corrupció publicats pel CGPJ via la seva API de dades obertes.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+# API pública d'estadística judicial del CGPJ
+BASE_URL = "https://www.poderjudicial.es"
+STATS_API = f"{BASE_URL}/cgpj/es/Temas/Estadistica-Judicial/Estadistica-por-Temas"
+REQUEST_TIMEOUT = 30.0
+
+# URL del repositori de dades sobre processos per corrupció
+CORRUPCION_URL = (
+    f"{BASE_URL}/cgpj/es/Temas/Transparencia/Repositorio-de-datos-sobre"
+    "-procesos-por-corrupcion/"
+)
+
+# Endpoint PC-Axis per estadístiques judicials
+PCAXIS_API = f"{BASE_URL}/stj/pcaxis"
+
+
+async def buscar_estadistiques_judicials(
+    *,
+    tema: str | None = None,
+    territori: str | None = None,
+    any_: str | None = None,
+) -> dict:
+    """Cerca estadístiques judicials al CGPJ.
+
+    Args:
+        tema: Tema de l'estadística (ex: 'penal', 'civil', 'contencioso').
+        territori: Àmbit territorial (ex: 'nacional', 'Madrid', 'Barcelona').
+        any_: Any de les estadístiques.
+    """
+    params: dict[str, str] = {}
+    if tema:
+        params["tema"] = tema
+    if territori:
+        params["territorio"] = territori
+    if any_:
+        params["anio"] = any_
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, follow_redirects=True) as client:
+        resp = await client.get(f"{PCAXIS_API}/juzgados.json", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def obtenir_dades_corrupcio() -> dict:
+    """Obté les dades del repositori de processos per corrupció del CGPJ.
+
+    Retorna informació sobre procediments judicials per corrupció
+    incloent: macrocauses, causes a Audiència Nacional i tribunals
+    superiors de justícia.
+    """
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, follow_redirects=True) as client:
+        # Intentar obtenir dades via la API JSON
+        resp = await client.get(
+            f"{PCAXIS_API}/corrupcion.json",
+        )
+        if resp.status_code == 200:
+            return resp.json()
+
+        # Fallback: obtenir la pàgina HTML del repositori
+        resp = await client.get(CORRUPCION_URL)
+        resp.raise_for_status()
+        return {
+            "font": CORRUPCION_URL,
+            "nota": (
+                "Les dades de corrupció del CGPJ es publiquen com a informes "
+                "PDF i taules estadístiques. Consulta la URL font per accedir "
+                "als documents complets."
+            ),
+            "url_repositori": CORRUPCION_URL,
+            "status": resp.status_code,
+        }
+
+
+async def cercar_sentencies(
+    *,
+    text: str | None = None,
+    organ: str | None = None,
+    tipus: str | None = None,
+    data_desde: str | None = None,
+    data_fins: str | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> dict:
+    """Cerca sentències al Centre de Documentació Judicial (CENDOJ).
+
+    Args:
+        text: Text lliure per cercar a les resolucions.
+        organ: Tipus d'òrgan judicial (ex: 'TS' Tribunal Suprem,
+               'AN' Audiència Nacional, 'AP' Audiència Provincial).
+        tipus: Tipus de resolució (ex: 'SENTENCIA', 'AUTO').
+        data_desde: Data inici DD/MM/YYYY.
+        data_fins: Data fi DD/MM/YYYY.
+        page: Pàgina de resultats.
+        page_size: Resultats per pàgina.
+    """
+    params: dict[str, str | int] = {
+        "page": page,
+        "pageSize": page_size,
+    }
+    if text:
+        params["q"] = text
+    if organ:
+        params["organ"] = organ
+    if tipus:
+        params["tipo"] = tipus
+    if data_desde:
+        params["fechaDesde"] = data_desde
+    if data_fins:
+        params["fechaHasta"] = data_fins
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, follow_redirects=True) as client:
+        resp = await client.get(
+            f"{BASE_URL}/search/indexAN",
+            params=params,
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/src/mcp_govern/datasets.py
+++ b/src/mcp_govern/datasets.py
@@ -584,6 +584,98 @@ DATASETS = {
             "curs",
         ],
     },
+    # =======================================================================
+    # FISCALITAT
+    # =======================================================================
+    "impost_successions_composicio": {
+        "id": "2jqq-fyu8",
+        "nom": "Impost sobre successions per composició de l'herència",
+        "camps": [],
+    },
+    "impost_successions_quota": {
+        "id": "xaxt-fghh",
+        "nom": "Impost sobre successions - càlcul de la quota final",
+        "camps": [],
+    },
+    # =======================================================================
+    # RETRIBUCIONS - CÀRRECS LOCALS
+    # =======================================================================
+    "retrib_carrecs_locals": {
+        "id": "bepu-nr6b",
+        "nom": "Indicadors retributius dels càrrecs electes locals",
+        "camps": [],
+    },
+    # =======================================================================
+    # PARTICIPACIÓ I OPINIÓ
+    # =======================================================================
+    "enquestes_opinio": {
+        "id": "gp4k-sxxn",
+        "nom": "Microdades d'estudis d'opinió",
+        "camps": [],
+    },
+    "participacio_ciutadana": {
+        "id": "62wr-uxxx",
+        "nom": "Panel de participació ciutadana en polítiques públiques locals",
+        "camps": [],
+    },
+    # =======================================================================
+    # PERSONAL - ACORDS I CONVENIS
+    # =======================================================================
+    "acords_personal": {
+        "id": "j98z-54w6",
+        "nom": "Acords i pactes de condicions de treball del personal",
+        "camps": [],
+    },
+    # =======================================================================
+    # CONTRACTACIÓ LOCAL
+    # =======================================================================
+    "relic": {
+        "id": "t3wj-j4pu",
+        "nom": "Registre públic de contractes d'ens locals (RELIC)",
+        "camps": [],
+    },
+    # =======================================================================
+    # SERVEIS SOCIALS
+    # =======================================================================
+    "serveis_residencials_violencia": {
+        "id": "vqd5-kgke",
+        "nom": "Serveis residencials per a dones en situació de violència",
+        "camps": [],
+    },
+    # =======================================================================
+    # EDUCACIÓ
+    # =======================================================================
+    "centres_fp": {
+        "id": "iyus-443e",
+        "nom": "Centres de formació professional integrada de Catalunya",
+        "camps": [],
+    },
+    # =======================================================================
+    # INFRAESTRUCTURES I MEDI AMBIENT
+    # =======================================================================
+    "ports": {
+        "id": "frcw-v3xi",
+        "nom": "Ports de Catalunya - infraestructures portuàries",
+        "camps": [],
+    },
+    "depuradores": {
+        "id": "k288-dig3",
+        "nom": "Sistemes públics de sanejament i depuradores d'aigües residuals",
+        "camps": [],
+    },
+    "economia_circular": {
+        "id": "5jbn-usiv",
+        "nom": "Iniciatives Catalunya Circular",
+        "camps": [],
+    },
+    # =======================================================================
+    # AGRICULTURA
+    # =======================================================================
+    "explotacions_agraries": {
+        "id": "uwe8-jqcu",
+        "nom": "Parcel·les i cultius de les explotacions agràries (DUN)",
+        "camps": [],
+    },
 }
 
 

--- a/src/mcp_govern/datosgob.py
+++ b/src/mcp_govern/datosgob.py
@@ -1,0 +1,94 @@
+"""Client async per a la API de datos.gob.es (catàleg nacional de dades obertes)."""
+
+from __future__ import annotations
+
+import httpx
+
+BASE_URL = "https://datos.gob.es/apidata"
+REQUEST_TIMEOUT = 30.0
+DEFAULT_PAGE_SIZE = 20
+
+
+async def buscar_datasets(
+    *,
+    query: str | None = None,
+    theme: str | None = None,
+    publisher: str | None = None,
+    format_: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    page: int = 0,
+) -> dict:
+    """Cerca datasets al catàleg nacional de dades obertes.
+
+    Args:
+        query: Text lliure per cercar als títols i descripcions.
+        theme: Temàtica (ex: 'sector-publico', 'economia', 'hacienda').
+        publisher: Organisme publicador.
+        format_: Format dels recursos (ex: 'json', 'csv', 'api').
+        page_size: Resultats per pàgina.
+        page: Número de pàgina (0-indexed).
+    """
+    params: dict[str, str | int] = {
+        "_pageSize": page_size,
+        "_page": page,
+        "_sort": "-modified",
+    }
+    if query:
+        params["q"] = query
+    if theme:
+        params["theme_id"] = f"http://datos.gob.es/kos/sector-publico/sector/{theme}"
+    if publisher:
+        params["publisher_display_name"] = publisher
+    if format_:
+        params["format"] = format_
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(f"{BASE_URL}/catalog/dataset.json", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def detall_dataset(dataset_id: str) -> dict:
+    """Obté el detall complet d'un dataset pel seu identificador.
+
+    Args:
+        dataset_id: Identificador del dataset (ex: 'l01080193-presupuestos-gastos').
+    """
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(
+            f"{BASE_URL}/catalog/dataset/{dataset_id}.json"
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def buscar_distribucions(
+    *,
+    dataset_id: str | None = None,
+    format_: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    page: int = 0,
+) -> dict:
+    """Cerca distribucions (fitxers/APIs) de datasets.
+
+    Args:
+        dataset_id: Filtrar per dataset concret.
+        format_: Format del recurs (ex: 'text/csv', 'application/json').
+        page_size: Resultats per pàgina.
+        page: Número de pàgina.
+    """
+    params: dict[str, str | int] = {
+        "_pageSize": page_size,
+        "_page": page,
+    }
+    if format_:
+        params["format"] = format_
+
+    url = f"{BASE_URL}/catalog/distribution.json"
+    if dataset_id:
+        url = f"{BASE_URL}/catalog/dataset/{dataset_id}/distribution.json"
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()

--- a/src/mcp_govern/server.py
+++ b/src/mcp_govern/server.py
@@ -8,7 +8,7 @@ from typing import Annotated
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from . import bdns, cgpj, datosgob, socrata
+from . import barcelona, bdns, cgpj, datosgob, socrata
 from .datasets import DATASETS
 
 _INSTRUCTIONS = """\
@@ -23,6 +23,8 @@ RLT, agenda lobbies, viatges, declaracions activitats.
 amb informació de contractació, pressupostos, economia i sector públic.
 - CGPJ (Espanya): estadístiques judicials, repositori de processos per corrupció \
 i cercador de sentències del CENDOJ.
+- Open Data BCN (Barcelona): 553 datasets municipals — pressupostos, contractes, \
+seguretat (incidents GUB), transport, medi ambient, habitatge i economia.
 
 ÚS DE LES TOOLS:
 - Sou d'un càrrec (president, conseller...): cercar_retribucions_alts_carrecs amb 'carrec'
@@ -36,6 +38,7 @@ i cercador de sentències del CENDOJ.
 - Dades de corrupció judicial: cgpj_dades_corrupcio
 - Sentències judicials: cgpj_cercar_sentencies
 - Estadístiques judicials: cgpj_estadistiques_judicials
+- Dades de Barcelona: bcn_cercar_datasets, bcn_detall_dataset, bcn_obtenir_dades
 
 PATRONS DE CORRUPCIÓ — Quan l'usuari demani investigar o analitzar, aplica \
 proactivament aquestes estratègies:
@@ -1312,6 +1315,117 @@ async def cgpj_estadistiques_judicials(
         any_=any_,
     )
     return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+# ===========================================================================
+# Open Data BCN — Ajuntament de Barcelona (API CKAN)
+# ===========================================================================
+
+
+@mcp.tool()
+async def bcn_cercar_datasets(
+    query: Annotated[str | None, Field(description="Text lliure per cercar (ex: 'pressupost', 'seguretat', 'habitatge')")] = None,
+    rows: Annotated[int, Field(description="Nombre de resultats (per defecte 20)")] = 20,
+    start: Annotated[int, Field(description="Offset per paginació")] = 0,
+) -> str:
+    """Cerca datasets a l'Open Data de l'Ajuntament de Barcelona.
+
+    553 datasets municipals sobre: pressupostos, contractes, seguretat
+    (incidents Guàrdia Urbana), transport (bicing, bus, taxi), medi ambient
+    (qualitat aire, espais verds), habitatge, urbanisme i economia.
+    """
+    result = await barcelona.cercar_datasets(query=query, rows=rows, start=start)
+    if not result.get("success"):
+        return "Error en la consulta a Open Data BCN."
+
+    results = result.get("result", {})
+    count = results.get("count", 0)
+    datasets = results.get("results", [])
+
+    if not datasets:
+        return "No s'han trobat datasets a Barcelona."
+
+    records = []
+    for ds in datasets:
+        records.append({
+            "nom": ds.get("title", ""),
+            "id": ds.get("name", ""),
+            "descripcio": (ds.get("notes_translated", {}).get("ca", "") or ds.get("notes", ""))[:200],
+            "num_recursos": ds.get("num_resources", 0),
+            "etiquetes": [t.get("name", "") for t in ds.get("tags", [])],
+        })
+
+    header = f"Total: {count} datasets trobats.\n\n"
+    return header + json.dumps(records, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def bcn_detall_dataset(
+    dataset_name: Annotated[str, Field(description=(
+        "Nom del dataset. Exemples: 'pressupost-despeses', 'pressupost-ingressos', "
+        "'contractes-menors', 'incidents-gestionats-gub', 'qualitat-aire-detall-bcn', "
+        "'habitatges-us-turistic', 'bicing', 'obres', 'renda-disponible-llars-bcn'"
+    ))],
+) -> str:
+    """Obté el detall complet d'un dataset de Barcelona, incloent els seus recursos.
+
+    Retorna metadades i la llista de recursos (fitxers CSV, JSON, etc.)
+    amb els seus resource_id per poder consultar-los amb bcn_obtenir_dades.
+    """
+    result = await barcelona.detall_dataset(dataset_name)
+    if not result.get("success"):
+        return f"No s'ha trobat el dataset '{dataset_name}'."
+
+    ds = result.get("result", {})
+    resources = []
+    for r in ds.get("resources", []):
+        resources.append({
+            "id": r.get("id", ""),
+            "nom": r.get("name", ""),
+            "format": r.get("format", ""),
+            "url": r.get("url", ""),
+        })
+
+    info = {
+        "nom": ds.get("title", ""),
+        "descripcio": ds.get("notes_translated", {}).get("ca", "") or ds.get("notes", ""),
+        "llicencia": ds.get("license_title", ""),
+        "recursos": resources,
+    }
+    return json.dumps(info, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def bcn_obtenir_dades(
+    resource_id: Annotated[str, Field(description="ID del recurs (obtingut via bcn_detall_dataset)")],
+    query: Annotated[str | None, Field(description="Text lliure per filtrar les dades")] = None,
+    limit: Annotated[int, Field(description="Nombre de resultats (per defecte 20)")] = 20,
+    offset: Annotated[int, Field(description="Offset per paginació")] = 0,
+) -> str:
+    """Obté dades d'un recurs concret de Barcelona via l'API datastore.
+
+    Primer usa bcn_detall_dataset per obtenir els resource_id disponibles,
+    després aquesta tool per consultar les dades reals.
+    """
+    result = await barcelona.obtenir_dades(
+        resource_id, query=query, limit=limit, offset=offset,
+    )
+    if not result.get("success"):
+        return "Error obtenint dades del recurs."
+
+    data = result.get("result", {})
+    records = data.get("records", [])
+    total = data.get("total", 0)
+
+    if not records:
+        return "No s'han trobat registres."
+
+    header = ""
+    if total:
+        shown = len(records)
+        header = f"Mostrant {offset + 1}-{offset + shown} de {total} registres.\n\n"
+
+    return header + json.dumps(records, ensure_ascii=False, indent=2)
 
 
 def main():

--- a/src/mcp_govern/server.py
+++ b/src/mcp_govern/server.py
@@ -1,4 +1,4 @@
-"""MCP server per consultar dades obertes del Govern de Catalunya."""
+"""MCP server per consultar dades obertes del Govern de Catalunya i d'Espanya."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import Annotated
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from . import bdns, socrata
+from . import bdns, cgpj, datosgob, socrata
 from .datasets import DATASETS
 
 _INSTRUCTIONS = """\
@@ -19,6 +19,10 @@ FONTS DE DADES:
 - Socrata (Catalunya): contractes, subvencions RAISC, retribucions, pressupostos, \
 RLT, agenda lobbies, viatges, declaracions activitats.
 - BDNS (Espanya): subvencions amb noms reals de beneficiaris (persones físiques i jurídiques).
+- datos.gob.es (Espanya): catàleg nacional de dades obertes (113.000+ datasets) \
+amb informació de contractació, pressupostos, economia i sector públic.
+- CGPJ (Espanya): estadístiques judicials, repositori de processos per corrupció \
+i cercador de sentències del CENDOJ.
 
 ÚS DE LES TOOLS:
 - Sou d'un càrrec (president, conseller...): cercar_retribucions_alts_carrecs amb 'carrec'
@@ -28,6 +32,10 @@ RLT, agenda lobbies, viatges, declaracions activitats.
 - Subvencions amb noms reals: bdns_cercar_concessions
 - Estadístiques agregades: estadistiques (usa llistar_camps abans)
 - Investigació completa d'una entitat/persona: investigar_entitat
+- Datasets nacionals d'Espanya: datosgob_cercar_datasets + datosgob_detall_dataset
+- Dades de corrupció judicial: cgpj_dades_corrupcio
+- Sentències judicials: cgpj_cercar_sentencies
+- Estadístiques judicials: cgpj_estadistiques_judicials
 
 PATRONS DE CORRUPCIÓ — Quan l'usuari demani investigar o analitzar, aplica \
 proactivament aquestes estratègies:
@@ -1163,6 +1171,147 @@ async def detectar_fraccionament(
         lines.append(f"\n... i {total - 20} contractes més.")
 
     return "\n".join(lines)
+
+
+# ===========================================================================
+# datos.gob.es — Catàleg nacional de dades obertes
+# ===========================================================================
+
+
+@mcp.tool()
+async def datosgob_cercar_datasets(
+    query: Annotated[str | None, Field(description="Text lliure per cercar (ex: 'contratos públicos', 'presupuestos')")] = None,
+    theme: Annotated[str | None, Field(description="Temàtica: 'sector-publico', 'economia', 'hacienda', 'empleo', 'medio-ambiente', 'salud', 'educacion', 'transporte'")] = None,
+    publisher: Annotated[str | None, Field(description="Organisme publicador (ex: 'Ministerio de Hacienda')")] = None,
+    format_: Annotated[str | None, Field(description="Format dels recursos: 'json', 'csv', 'api', 'xml'")] = None,
+    page_size: Annotated[int, Field(description="Resultats per pàgina (per defecte 20)")] = 20,
+    page: Annotated[int, Field(description="Pàgina (0-indexed)")] = 0,
+) -> str:
+    """Cerca datasets al catàleg nacional de dades obertes datos.gob.es.
+
+    Permet trobar datasets publicats per administracions espanyoles sobre
+    contractació, pressupostos, economia, sector públic i molt més.
+    Hi ha 113.000+ datasets disponibles.
+    """
+    result = await datosgob.buscar_datasets(
+        query=query,
+        theme=theme,
+        publisher=publisher,
+        format_=format_,
+        page_size=page_size,
+        page=page,
+    )
+    items = result.get("result", {}).get("items", [])
+    if not items:
+        return "No s'han trobat datasets."
+
+    total_str = ""
+    total_results = result.get("result", {}).get("totalResults")
+    if total_results:
+        total_str = f"Total: {total_results} datasets trobats.\n\n"
+
+    records = []
+    for item in items:
+        title = item.get("title", "")
+        if isinstance(title, list):
+            title = title[0] if title else ""
+        elif isinstance(title, dict):
+            title = title.get("_value", title.get("es", str(title)))
+        desc = item.get("description", "")
+        if isinstance(desc, list):
+            desc = desc[0] if desc else ""
+        elif isinstance(desc, dict):
+            desc = desc.get("_value", desc.get("es", str(desc)))
+        records.append({
+            "titol": title,
+            "descripcio": str(desc)[:200],
+            "id": item.get("identifier", ""),
+            "publicador": item.get("publisher", ""),
+            "modificat": item.get("modified", ""),
+            "llicencia": item.get("license", ""),
+        })
+
+    return total_str + json.dumps(records, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def datosgob_detall_dataset(
+    dataset_id: Annotated[str, Field(description="Identificador del dataset (obtingut via datosgob_cercar_datasets)")],
+) -> str:
+    """Obté el detall complet d'un dataset de datos.gob.es.
+
+    Inclou distribucions (fitxers descarregables, APIs), metadades,
+    freqüència d'actualització i recursos disponibles.
+    """
+    result = await datosgob.detall_dataset(dataset_id)
+    items = result.get("result", {}).get("items", [])
+    if not items:
+        return f"No s'ha trobat el dataset amb id '{dataset_id}'."
+    return json.dumps(items[0], ensure_ascii=False, indent=2)
+
+
+# ===========================================================================
+# CGPJ — Consejo General del Poder Judicial
+# ===========================================================================
+
+
+@mcp.tool()
+async def cgpj_dades_corrupcio() -> str:
+    """Obté dades del repositori de processos per corrupció del CGPJ.
+
+    El CGPJ publica un repositori específic amb informació sobre
+    macrocauses, procediments a l'Audiència Nacional i als tribunals
+    superiors de justícia relacionats amb corrupció política i econòmica.
+    """
+    result = await cgpj.obtenir_dades_corrupcio()
+    return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def cgpj_cercar_sentencies(
+    text: Annotated[str | None, Field(description="Text lliure per cercar a les resolucions (ex: 'malversación', 'cohecho', 'prevaricación')")] = None,
+    organ: Annotated[str | None, Field(description="Tipus d'òrgan: 'TS' (Tribunal Suprem), 'AN' (Audiència Nacional), 'AP' (Audiència Provincial)")] = None,
+    tipus: Annotated[str | None, Field(description="Tipus de resolució: 'SENTENCIA', 'AUTO'")] = None,
+    data_desde: Annotated[str | None, Field(description="Data inici DD/MM/YYYY")] = None,
+    data_fins: Annotated[str | None, Field(description="Data fi DD/MM/YYYY")] = None,
+    page: Annotated[int, Field(description="Pàgina de resultats")] = 1,
+    page_size: Annotated[int, Field(description="Resultats per pàgina")] = 20,
+) -> str:
+    """Cerca sentències al CENDOJ (Centre de Documentació Judicial).
+
+    Permet cercar resolucions judicials per text, òrgan judicial, tipus
+    i dates. Molt útil per trobar sentències de corrupció, malversació,
+    prevaricació, suborn i altres delictes contra l'administració pública.
+    """
+    result = await cgpj.cercar_sentencies(
+        text=text,
+        organ=organ,
+        tipus=tipus,
+        data_desde=data_desde,
+        data_fins=data_fins,
+        page=page,
+        page_size=page_size,
+    )
+    return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def cgpj_estadistiques_judicials(
+    tema: Annotated[str | None, Field(description="Tema: 'penal', 'civil', 'contencioso', 'social', 'menores'")] = None,
+    territori: Annotated[str | None, Field(description="Àmbit territorial (ex: 'nacional', 'Madrid', 'Barcelona', 'Cataluña')")] = None,
+    any_: Annotated[str | None, Field(description="Any de les estadístiques (ex: '2024')")] = None,
+) -> str:
+    """Consulta estadístiques judicials del CGPJ.
+
+    Dades agregades sobre activitat judicial per tema, territori i any.
+    Inclou volum de procediments, durada, taxes de resolució, etc.
+    """
+    result = await cgpj.buscar_estadistiques_judicials(
+        tema=tema,
+        territori=territori,
+        any_=any_,
+    )
+    return json.dumps(result, ensure_ascii=False, indent=2)
 
 
 def main():


### PR DESCRIPTION
## Summary

### New data source modules
- **`datosgob.py`**: Async client for datos.gob.es national open data catalog API (113k+ datasets)
- **`cgpj.py`**: Async client for CGPJ — judicial statistics, corruption proceedings repository, CENDOJ sentence search
- **`barcelona.py`**: Async client for Barcelona Open Data (CKAN API) — 553 municipal datasets

### New tools (8 total)
- `datosgob_cercar_datasets` — Search national open data catalog
- `datosgob_detall_dataset` — Get full dataset details and download links
- `cgpj_dades_corrupcio` — Access CGPJ corruption proceedings repository
- `cgpj_cercar_sentencies` — Search judicial sentences (CENDOJ)
- `cgpj_estadistiques_judicials` — Query judicial statistics by topic/territory/year
- `bcn_cercar_datasets` — Search Barcelona municipal datasets
- `bcn_detall_dataset` — Get dataset details with resource IDs
- `bcn_obtenir_dades` — Query actual data from Barcelona resources

### 14 new Socrata datasets in datasets.py
- **Fiscal**: inheritance tax (composition + final quota)
- **Local salaries**: elected officials compensation indicators (alcaldes, regidors)
- **Participation**: opinion surveys microdata, citizen participation panel
- **Labor**: staff agreements and pacts
- **Local contracts**: RELIC registry (municipal procurement)
- **Social services**: residential services for domestic violence
- **Education**: integrated vocational training centers
- **Infrastructure**: ports, wastewater treatment plants
- **Environment**: circular economy initiatives
- **Agriculture**: agricultural plots and crops (DUN)

## Why

Extends coverage from Catalunya+BDNS to include:
- **All national open data** via datos.gob.es (public REST API)
- **Judicial corruption data** via CGPJ — official repository of corruption proceedings
- **Barcelona municipal data** via CKAN API — budgets, contracts, security incidents, transport, housing
- **14 additional Catalan datasets** covering fiscal, social, environmental and local governance data

## Notes

- All APIs are public, no authentication required
- Follows existing code patterns (async httpx, same tool decorator style)
- Barcelona uses CKAN API (different from Socrata) — 3-step flow: search → detail → data
- New Socrata datasets have empty `camps` lists (fields auto-discoverable via existing `llistar_camps` tool)

## Test plan

- [ ] `datosgob_cercar_datasets` returns results for "contratos públicos"
- [ ] `cgpj_dades_corrupcio` returns corruption repository data
- [ ] `cgpj_cercar_sentencies` returns results for "malversación"
- [ ] `bcn_cercar_datasets` returns results for "pressupost"
- [ ] `bcn_detall_dataset` returns resources for "pressupost-despeses"
- [ ] `bcn_obtenir_dades` returns actual budget data
- [ ] Existing tools are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)